### PR TITLE
fix!: support node.js 10 and up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node8:
-          filters: *release_tags
       - node10:
           filters: *release_tags
       - node12:
@@ -30,7 +28,6 @@ workflows:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node8
             - node10
             - node12
             - node13
@@ -40,11 +37,6 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node8:
-    docker:
-      - image: node:8
-        user: node
-    <<: *unit_tests
   node10:
     docker:
       - image: node:10

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "tmp": "0.1.0"
   },
   "engines": {
-    "node": ">=8.x"
+    "node": ">=10.x"
   },
   "c8": {
     "exclude": [


### PR DESCRIPTION
BREAKING CHANGE: This change drops explicit support for node.js 8.x, and below.  Please upgrade to an LTS supported version :)